### PR TITLE
Use -j option when running make.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ script:
 
 matrix:
   allow_failures:
+    - rust: beta
     - rust: nightly
 
 env:

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -5,9 +5,10 @@ set -eux
 BUILD_DIR=$PWD
 MAKE_FLAGS=""
 
-# Currently only Linux is supported.
+# Please try and add other distributions.
 case "$(uname)" in
     "Linux") MAKE_FLAGS="-j$(nproc)";;
+    "Darwin") MAKE_FLAGS="-j$(sysctl -n hw.ncpu)"
 esac
 
 #

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -3,6 +3,12 @@
 set -eux
 
 BUILD_DIR=$PWD
+MAKE_FLAGS=""
+
+# Currently only Linux is supported.
+case "$(uname)" in
+    "Linux") MAKE_FLAGS="-j$(nproc)";;
+esac
 
 #
 # gf-complete
@@ -12,7 +18,7 @@ cd gf-complete/
 git checkout a6862d1
 ./autogen.sh
 ./configure --disable-shared --with-pic --prefix $BUILD_DIR
-make install
+make $MAKE_FLAGS install
 cd ../
 
 #
@@ -23,7 +29,7 @@ cd jerasure/
 git checkout de1739c
 autoreconf --force --install
 CFLAGS="-I${BUILD_DIR}/include" LDFLAGS="-L${BUILD_DIR}/lib" ./configure --disable-shared --enable-static --with-pic --prefix $BUILD_DIR
-make install
+make $MAKE_FLAGS install
 cd ../
 
 #
@@ -39,4 +45,4 @@ if [ "$(uname)" == "Darwin" ]; then
 fi
 CFLAGS=$CFLAGS LIBS="-lJerasure" LDFLAGS="-L${BUILD_DIR}/lib" ./configure --disable-shared --with-pic --prefix $BUILD_DIR
 patch -p1 < ../liberasurecode.patch # Applies a patch for building static library
-make install
+make $MAKE_FLAGS install


### PR DESCRIPTION
Make build a bit faster using `-j` option.

# Before

```console
$ time cargo build
   Compiling liberasurecode v1.0.2
   Compiling libc v0.2.43
    Finished dev [unoptimized + debuginfo] target(s) in 1m 19s
cargo build  62.55s user 12.33s system 94% cpu 1:19.38 total
```

# After

```console
$ time cargo build
   Compiling liberasurecode v1.0.2
   Compiling libc v0.2.43
    Finished dev [unoptimized + debuginfo] target(s) in 1m 05s
cargo build  61.67s user 11.71s system 112% cpu 1:05.20 total
```
