### PR TITLE
Validates the index passed to reconstruct function.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
   - rustup component add clippy-preview
 
 script:
-  - cargo test
+  - cargo test -- --test-threads=1
   - cargo clippy
 
 matrix:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,15 +273,17 @@ impl ErasureCoder {
     }
 
     /// Reconstructs the fragment specified by the given index from other available fragments.
-    /// The index must be lower than the total number of parity_fragments and data_fragments.
+    ///
+    /// # Errors
+    ///
+    /// This function will return `Error::InvalidParams` if the given index is bigger or equal
+    /// than the total number of parity_fragments and data_fragments.
     pub fn reconstruct<T, F>(&mut self, index: usize, available_fragments: T) -> Result<Vec<u8>>
     where
         T: Iterator<Item = F>,
         F: AsRef<[u8]>,
     {
-        let upper_bound = self.parity_fragments.get() + self.data_fragments.get();
-
-        if index >= upper_bound {
+        if index >= self.fragments().get() {
             return Err(Error::InvalidParams);
         }
 


### PR DESCRIPTION
This validation prevents crashes(invalid memory reference) caused by the internal of openstack/liberasurecode.

Change the test case to the following code(set `index` to 9) to see what happens:

```rust
    #[test]
    fn reconstruct_works() {
        // ...
        for i in 0..coder.fragments().get() {
            assert_eq!(
                coder.reconstruct(
                    9, // index out of bound
                    encoded
                        .iter()
                        // ...
                ),
                Ok(encoded[i].clone())
            );
        }
    }

//error: process didn't exit successfully: `liberasurecode/target/debug/deps/liberasurecode-6972ecd8d60e4e40` (signal: 11, SIGSEGV: invalid memory reference)

```