### PR TITLE
Patch for issue7

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,7 +11,11 @@ fn main() {
     let _ = fs::remove_dir_all(&build_dir);
     fs::create_dir(&build_dir).unwrap();
 
-    for file in &["install_deps.sh", "liberasurecode.patch"] {
+    for file in &[
+        "install_deps.sh",
+        "liberasurecode.patch",
+        "for_darwin_to_detect_compiler_flag.patch",
+    ] {
         fs::copy(file, build_dir.join(file)).unwrap();
     }
 

--- a/for_darwin_to_detect_compiler_flag.patch
+++ b/for_darwin_to_detect_compiler_flag.patch
@@ -1,0 +1,23 @@
+--- a/configure.ac	2019-04-19 16:27:52.000000000 +0900
++++ b/configure.ac	2019-04-19 16:26:06.000000000 +0900
+@@ -39,6 +39,20 @@ AC_PROG_LN_S
+ dnl Compiling with per-target flags requires AM_PROG_CC_C_O.
+ AC_PROG_CC
+ AM_PROG_CC_C_O
++
++# Check if a compiler supports "-Wno-error=address-of-packed-member"
++# If it supports the option, we add it to CFLAGS.
++ac_save_CFLAGS="$CFLAGS"
++AC_LANG_PUSH([C])
++CFLAGS="-Wno-error=address-of-packed-member"
++AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],[[]])],
++[ac_c_recognize_address_of_packed_member=1],
++[ac_c_recognize_address_of_packed_member=0])
++AC_LANG_POP([C])
++AS_IF([test $ac_c_recognize_address_of_packed_member -eq 1],
++[CFLAGS="$ac_save_CFLAGS -Wno-error=address-of-packed-member"],
++[CFLAGS="$ac_save_CFLAGS"])
++
+ AC_PROG_LIBTOOL
+ AC_PROG_CXX
+ AC_PROG_INSTALL

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -39,11 +39,13 @@ cd ../
 git clone https://github.com/openstack/liberasurecode.git
 cd liberasurecode/
 git checkout 1.5.0
+if [ "$(uname)" == "Darwin" ]; then
+    # if the compiler has the feature to check `address-of-packed-member`, we suppress it.
+    # it is only annoying for liberasurecode v1.5.0.
+    patch -p1 < ../for_darwin_to_detect_compiler_flag.patch
+fi
 ./autogen.sh
 CFLAGS="-I${BUILD_DIR}/jerasure/include -I${BUILD_DIR}/include"
-if [ "$(uname)" == "Darwin" ]; then
-    CFLAGS="$CFLAGS -Wno-error=address-of-packed-member"
-fi
 CFLAGS=$CFLAGS LIBS="-lJerasure" LDFLAGS="-L${BUILD_DIR}/lib" ./configure --disable-shared --with-pic --prefix $BUILD_DIR
 patch -p1 < ../liberasurecode.patch # Applies a patch for building static library
 make $MAKE_FLAGS install


### PR DESCRIPTION
# Goal
Solves the issue https://github.com/frugalos/liberasurecode/issues/7

# Implementation
The core change is the patch `for_darwin_to_detect_compiler_flag.patch`.

Applying the patch to `configure.ac`, it checks if the compiler that is used to build `liberasurecode` can recognize the option `Wno-error=address-of-packed-member`.

In this PR, we only apply the patch if we try to build `liberasurecode` on Darwin.

# Alternative Approach
The current `liberasurecode` v1.6.0 (meanwhile, now we are using v1.5.0) solves the same problem on the code level by [this commit](https://github.com/openstack/liberasurecode/commit/e426aee95b616778e4a8e484c3a56c691a2b9c52).

Therefore, if we would upgrade the version to v1.6.0, this issue is solved in a more natural way.