### PR TITLE
fit to the latest clippy 0.0.212 (of 1.34.0) & apply the latest rust-fmt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,8 @@ impl Builder {
                     data_fragments: self.data_fragments,
                     parity_fragments: self.parity_fragments,
                     desc,
-                }).map_err(Error::from_error_code)?;
+                })
+                .map_err(Error::from_error_code)?;
 
             // `SIGSEGV` may be raised if encodings are executed (in parallel) immediately after creation.
             // To prevent it, sleeps the current thread for a little while.
@@ -263,7 +264,7 @@ impl ErasureCoder {
         if fragments.is_empty() {
             return Err(Error::InsufficientFragments);;
         }
-        let data_fragments = &fragments.iter().map(|x| x.as_ref()).collect::<Vec<_>>()[..];
+        let data_fragments = &fragments.iter().map(AsRef::as_ref).collect::<Vec<_>>()[..];
 
         let (data, data_len) =
             c_api::decode(self.desc, data_fragments, false).map_err(Error::from_error_code)?;
@@ -288,7 +289,7 @@ impl ErasureCoder {
         }
 
         let fragments = available_fragments.collect::<Vec<_>>();
-        let fragments = fragments.iter().map(|x| x.as_ref()).collect::<Vec<_>>();
+        let fragments = fragments.iter().map(AsRef::as_ref).collect::<Vec<_>>();
         c_api::reconstruct_fragment(self.desc, &fragments[..], index)
             .map_err(Error::from_error_code)
     }


### PR DESCRIPTION
# Motivation
After migrating to Rust 1.34.0, the latest clippy of Rust 1.34.0 (`clippy 0.0.212 (1fac3808 2019-02-20)`) warns as follows:
```shell
warning: redundant closure found
   --> src/lib.rs:266:52
    |
266 |         let data_fragments = &fragments.iter().map(|x| x.as_ref()).collect::<Vec<_>>()[..];
    |                                                    ^^^^^^^^^^^^^^ help: remove closure as shown: `std::convert::AsRef::as_ref`
    |
    = note: #[warn(clippy::redundant_closure)] on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure

warning: redundant closure found
   --> src/lib.rs:291:46
    |
291 |         let fragments = fragments.iter().map(|x| x.as_ref()).collect::<Vec<_>>();
    |                                              ^^^^^^^^^^^^^^ help: remove closure as shown: `std::convert::AsRef::as_ref`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure
```

This PR suppress the above messages by the following suggestions generated by the Clippy.

This PR also performs the latest `rust-fmt`.