### PR TITLE
Upgrade liberasurecode 1.5.0 -> 1.6.1

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -34,18 +34,24 @@ make $MAKE_FLAGS install
 cd ../
 
 #
+# zlib, introduced in liberasurecode 1.5.0 -> 1.6.0
+#
+
+git clone https://github.com/madler/zlib.git
+cd zlib
+git checkout cacf7f1 # tag: v1.2.11
+CFLAGS="-I${BUILD_DIR}/include -fPIC" LDFLAGS="-L${BUILD_DIR}/lib" ./configure --prefix $BUILD_DIR
+make $MAKE_FLAGS install
+cd ../
+
+#
 # liberasurecode
 #
 git clone https://github.com/openstack/liberasurecode.git
 cd liberasurecode/
-git checkout 1.5.0
-if [ "$(uname)" == "Darwin" ]; then
-    # if the compiler has the feature to check `address-of-packed-member`, we suppress it.
-    # it is only annoying for liberasurecode v1.5.0.
-    patch -p1 < ../for_darwin_to_detect_compiler_flag.patch
-fi
+git checkout 1.6.1
 ./autogen.sh
 CFLAGS="-I${BUILD_DIR}/jerasure/include -I${BUILD_DIR}/include"
-CFLAGS=$CFLAGS LIBS="-lJerasure" LDFLAGS="-L${BUILD_DIR}/lib" ./configure --disable-shared --with-pic --prefix $BUILD_DIR
+CFLAGS=$CFLAGS LIBS="-lJerasure -lz" LDFLAGS="-L${BUILD_DIR}/lib" ./configure --disable-shared --with-pic --prefix $BUILD_DIR
 patch -p1 < ../liberasurecode.patch # Applies a patch for building static library
 make $MAKE_FLAGS install

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -45,6 +45,7 @@ pub const EINSUFFFRAGS: u32 = 208;
 
 #[link(name = "erasurecode", kind = "static")]
 #[link(name = "gf_complete", kind = "static")]
+#[link(name = "z", kind = "static")]
 #[link(name = "Jerasure", kind = "static")]
 #[link(name = "Xorcode", kind = "static")]
 extern "C" {


### PR DESCRIPTION
Resolves https://github.com/frugalos/liberasurecode/issues/13.

Probably this PR needs to wait until https://github.com/frugalos/liberasurecode/pull/12 is merged. 