### PR TITLE
Optimize reconstructing of parity fragments

### DIFF
--- a/liberasurecode.patch
+++ b/liberasurecode.patch
@@ -11,7 +11,7 @@ index 52554a9..0a6863d 100644
    int *tbl1_r;
    int *tbl2_l;
 diff --git a/src/backends/jerasure/jerasure_rs_cauchy.c b/src/backends/jerasure/jerasure_rs_cauchy.c
-index 82d796a..12323c8 100644
+index 82d796a..9628314 100644
 --- a/src/backends/jerasure/jerasure_rs_cauchy.c
 +++ b/src/backends/jerasure/jerasure_rs_cauchy.c
 @@ -28,6 +28,8 @@
@@ -23,7 +23,17 @@ index 82d796a..12323c8 100644
  
  #include "erasurecode.h"
  #include "erasurecode_backend.h"
-@@ -147,6 +149,7 @@ static int jerasure_rs_cauchy_reconstruct(void *desc, char **data, char **parity
+@@ -104,6 +106,9 @@ struct jerasure_rs_cauchy_descriptor {
+ static void free_rs_cauchy_desc(
+         struct jerasure_rs_cauchy_descriptor *jerasure_desc );
+ 
++int *jerasure_bitmatrix_multiply(int *m1, int *m2, int r1, int c1,
++                                 int r2, int c2);
++
+ 
+ static int jerasure_rs_cauchy_encode(void *desc, char **data, char **parity,
+         int blocksize)
+@@ -147,6 +152,7 @@ static int jerasure_rs_cauchy_reconstruct(void *desc, char **data, char **parity
      int *erased = NULL;           /* k+m length list of erased frag ids */
      int *dm_ids = NULL;           /* k length list of fragment ids */
      int *decoding_matrix = NULL;  /* matrix for decoding */
@@ -31,7 +41,7 @@ index 82d796a..12323c8 100644
  
      struct jerasure_rs_cauchy_descriptor *jerasure_desc = 
          (struct jerasure_rs_cauchy_descriptor*) desc;
-@@ -180,26 +183,38 @@ static int jerasure_rs_cauchy_reconstruct(void *desc, char **data, char **parity
+@@ -180,26 +186,37 @@ static int jerasure_rs_cauchy_reconstruct(void *desc, char **data, char **parity
              goto out;
          }
      } else {
@@ -65,8 +75,7 @@ index 82d796a..12323c8 100644
 +          goto out;
 +        }
 +
-+        // Because in the patch jerasure is statically linked, this symbol is visible.
-+        decoding_row_prod = jerasure_matrix_multiply(decoding_row_orig, decoding_matrix, w, k * w, k * w, k * w, 1);
++        decoding_row_prod = jerasure_bitmatrix_multiply(decoding_row_orig, decoding_matrix, w, k * w, k * w, k * w);
 +        if (decoding_row_prod == NULL) {
 +          ret = -1;
 +          goto out;
@@ -84,7 +93,7 @@ index 82d796a..12323c8 100644
      
      return ret;
  }
-@@ -268,87 +283,16 @@ static void * jerasure_rs_cauchy_init(struct ec_backend_args *args,
+@@ -268,87 +285,16 @@ static void * jerasure_rs_cauchy_init(struct ec_backend_args *args,
          }
      }
  
@@ -181,6 +190,35 @@ index 82d796a..12323c8 100644
  
      /* setup the Cauchy matrices and schedules */
      desc->matrix = desc->cauchy_original_coding_matrix(k, m, w);
+@@ -474,3 +420,28 @@ struct ec_backend_common backend_jerasure_rs_cauchy = {
+                                            JERASURE_RS_CAUCHY_LIB_MINOR,
+                                            JERASURE_RS_CAUCHY_LIB_REV),
+ };
++
++// bitmatrix's counterpart of jerasure_matrix_multiply.
++// We implement this function because we don't want to depend on gf-complete, and therefore introduce unnecessary race conditions.
++// Semantically equivalent to jerasure_matrix_multiply(m1, m2, r1, c1, r2, c2, 1).
++int *jerasure_bitmatrix_multiply(int *m1, int *m2, int r1, int c1,
++                                 int r2, int c2)
++{
++  int *product, i, j, k;
++
++  product = (int *) malloc(sizeof(int)*r1*c2);
++  if (product == NULL) {
++    return NULL;
++  }
++
++  for (i = 0; i < r1*c2; i++) product[i] = 0;
++
++  for (i = 0; i < r1; i++) {
++    for (j = 0; j < c2; j++) {
++      for (k = 0; k < r2; k++) {
++        product[i*c2+j] ^= m1[i*c1+k] && m2[k*c2+j];
++      }
++    }
++  }
++  return product;
++}
 diff --git a/src/backends/jerasure/jerasure_rs_vand.c b/src/backends/jerasure/jerasure_rs_vand.c
 index 9395046..143e00f 100644
 --- a/src/backends/jerasure/jerasure_rs_vand.c

--- a/liberasurecode.patch
+++ b/liberasurecode.patch
@@ -11,7 +11,7 @@ index 52554a9..0a6863d 100644
    int *tbl1_r;
    int *tbl2_l;
 diff --git a/src/backends/jerasure/jerasure_rs_cauchy.c b/src/backends/jerasure/jerasure_rs_cauchy.c
-index 3a0365a..217413d 100644
+index 82d796a..12323c8 100644
 --- a/src/backends/jerasure/jerasure_rs_cauchy.c
 +++ b/src/backends/jerasure/jerasure_rs_cauchy.c
 @@ -28,6 +28,8 @@
@@ -23,7 +23,68 @@ index 3a0365a..217413d 100644
  
  #include "erasurecode.h"
  #include "erasurecode_backend.h"
-@@ -268,87 +270,16 @@ static void * jerasure_rs_cauchy_init(struct ec_backend_args *args,
+@@ -147,6 +149,7 @@ static int jerasure_rs_cauchy_reconstruct(void *desc, char **data, char **parity
+     int *erased = NULL;           /* k+m length list of erased frag ids */
+     int *dm_ids = NULL;           /* k length list of fragment ids */
+     int *decoding_matrix = NULL;  /* matrix for decoding */
++    int *decoding_row_prod = NULL; /* matrix row for decoding parity fragments */
+ 
+     struct jerasure_rs_cauchy_descriptor *jerasure_desc = 
+         (struct jerasure_rs_cauchy_descriptor*) desc;
+@@ -180,26 +183,38 @@ static int jerasure_rs_cauchy_reconstruct(void *desc, char **data, char **parity
+             goto out;
+         }
+     } else {
+-        /*
+-         * If it is parity we are reconstructing, then just call decode.
+-         * ToDo (KMG): We can do better than this, but this should perform just
+-         * fine for most cases.  We can adjust the decoding matrix like we
+-         * did with ISA-L.
+-         */
+-        jerasure_desc->jerasure_bitmatrix_decode(k, m, w,
+-                                             jerasure_desc->bitmatrix, 
+-                                             0, 
+-                                             missing_idxs,
+-                                             data, 
+-                                             parity, 
+-                                             blocksize, 
+-                                             PYECC_CAUCHY_PACKETSIZE); 
++        int *decoding_row_orig = jerasure_desc->bitmatrix + k * w * w * (destination_idx - k);
++
++        dm_ids = (int *) alloc_zeroed_buffer(sizeof(int) * k);
++        decoding_matrix = (int *) alloc_zeroed_buffer(sizeof(int *) * k * k * w * w);
++        erased = jerasure_desc->jerasure_erasures_to_erased(k, m, missing_idxs);
++        if (NULL == decoding_matrix || NULL == dm_ids || NULL == erased) {
++            goto out;
++        }
++
++        ret = jerasure_desc->jerasure_make_decoding_bitmatrix(k, m, w,
++                                               jerasure_desc->bitmatrix,
++                                               erased, decoding_matrix, dm_ids);
++        if (ret != 0) {
++          goto out;
++        }
++
++        // Because in the patch jerasure is statically linked, this symbol is visible.
++        decoding_row_prod = jerasure_matrix_multiply(decoding_row_orig, decoding_matrix, w, k * w, k * w, k * w, 1);
++        if (decoding_row_prod == NULL) {
++          ret = -1;
++          goto out;
++        }
++        jerasure_desc->jerasure_bitmatrix_dotprod(k, w,
++                               decoding_row_prod, dm_ids, destination_idx,
++                               data, parity, blocksize, PYECC_CAUCHY_PACKETSIZE);
+     }
+ 
+ out:
+     free(erased);
+     free(decoding_matrix);
+     free(dm_ids);
++    free(decoding_row_prod);
+     
+     return ret;
+ }
+@@ -268,87 +283,16 @@ static void * jerasure_rs_cauchy_init(struct ec_backend_args *args,
          }
      }
  
@@ -247,7 +308,7 @@ index 9395046..143e00f 100644
  
      /* Note that cauchy will return pyeclib_handle->w * PYECC_CAUCHY_PACKETSIZE * 8 */
 diff --git a/src/erasurecode.c b/src/erasurecode.c
-index fb6d5de..4c3d024 100644
+index d4a06c2..f039c44 100644
 --- a/src/erasurecode.c
 +++ b/src/erasurecode.c
 @@ -177,6 +177,9 @@ void* liberasurecode_backend_open(ec_backend_t instance)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,8 +373,10 @@ mod tests {
         let len = 0xc0de;
         let mut coder = ErasureCoder::new(non_zero(k), non_zero(m)).unwrap();
         let mut data = vec![0; len];
+        let mut seed: u32 = 0xdeadbeef;
         for i in 0..len {
-            data[i] = (i as u8).wrapping_mul(i as u8);
+            data[i] = (seed >> 16) as u8;
+            seed = seed.wrapping_mul(0x15151).wrapping_add(0x31111111);
         }
         let encoded = coder.encode(&data).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,6 +367,41 @@ mod tests {
     }
 
     #[test]
+    fn reconstruct_works_for_all_fragments() -> Result<()> {
+        let k = 6;
+        let m = 3;
+        let len = 0xc0de;
+        let mut coder = ErasureCoder::new(non_zero(k), non_zero(m)).unwrap();
+        let mut data = vec![0; len];
+        for i in 0..len {
+            data[i] = (i as u8).wrapping_mul(i as u8);
+        }
+        let encoded = coder.encode(&data).unwrap();
+
+        // Exhaustively checks all patterns.
+        for alive in 0usize..1 << (k + m) {
+            // If not exactly k fragments are alive, skip.
+            if alive.count_ones() as usize != k {
+                continue;
+            }
+            let mut fragments = vec![];
+            for i in 0..k + m {
+                if (alive & 1 << i) != 0 {
+                    fragments.push(encoded[i].clone());
+                }
+            }
+            assert_eq!(fragments.len(), k);
+            for index in 0..k + m {
+                if (alive & 1 << index) == 0 {
+                    // if index is not alive, reconstruct it and check the validity.
+                    let reconstructed = coder.reconstruct(index, fragments.iter())?;
+                    assert_eq!(reconstructed, encoded[index]);
+                }
+            }
+        }
+        Ok(())
+    }
+    #[test]
     fn reconstruct_fails() {
         let mut coder = ErasureCoder::new(non_zero(4), non_zero(4)).unwrap();
         let data = vec![0, 1, 2, 3];


### PR DESCRIPTION
## 概要
Modify openstack/liberasurecode and include these changes into the patch file.
In addition to that, unit tests that ensure the correctness of reconstruct's output are added.

Changes made to openstack/liberasurecode can be viewed at https://github.com/openstack/liberasurecode/compare/master...frugalos:tmp/test-modify-rs-cauchy.

## 挙動の変更点
rs_cauchy バックエンドを使用して parity フラグメントを reconstruct するときの挙動が変わる。
もともとの実装では jerasure_bitmatrix_decode を呼び出してdata, parity 全てのフラグメントを復元していたが、今回の実装で欲しいフラグメントだけを復元するようになる。これにより、parity フラグメントの reconstruct が k 倍速くなることが予期される。(k はデータフラグメントの個数)

## 数学的な説明
以降 k = (データフラグメントの個数), m = (パリティフラグメントの個数) とする。
liberasurecode のエンコーディングでは、データを k * n 行列 D として解釈し、それに対して行列を掛けることでパリティフラグメントを計算する、ということが行われる。
エンコード用の m * k 行列を A とすると、データフラグメントおよびパリティフラグメントは以下の等式を満たす。
<img src="https://latex.codecogs.com/gif.latex?\begin{pmatrix}&space;I_k&space;\\&space;A&space;\end{pmatrix}&space;\begin{pmatrix}&space;d_0&space;\\&space;\vdots&space;\\&space;d_{k-1}&space;\end{pmatrix}&space;=&space;\begin{pmatrix}&space;d_0&space;\\&space;\vdots&space;\\&space;d_{k-1}&space;\\&space;c_0&space;\\&space;\vdots&space;\\&space;c_{m&space;-&space;1}&space;\end{pmatrix}" />

デコード時については、生き残ったフラグメントを f_0, ..., f_{k-1} とすると、上の等式の行を適切に選んで抜き取ることで、ある B_f に対して
<img src="https://latex.codecogs.com/gif.latex?B_f&space;\begin{pmatrix}&space;d_0&space;\\&space;\vdots&space;\\&space;d_{k-1}&space;\end{pmatrix}&space;=&space;\begin{pmatrix}&space;f_0&space;\\&space;\vdots&space;\\&space;f_{k-1}&space;\end{pmatrix}">
となるので、B_f の逆行列を計算しフラグメントに掛けることで元の d_0, ..., d_{k - 1} が復元できる。
<img src="https://latex.codecogs.com/gif.latex?B_f^{-1}&space;\begin{pmatrix}&space;f_0&space;\\&space;\vdots&space;\\&space;f_{k-1}&space;\end{pmatrix}&space;=&space;\begin{pmatrix}&space;d_0&space;\\&space;\vdots&space;\\&space;d_{k-1}&space;\end{pmatrix}">
- B_f は常に可逆である。というよりもどう行を選んでも常に可逆であるように A がうまく設定される。([Cauchy matrix](https://en.wikipedia.org/wiki/Cauchy_matrix) を使っている。[コード](https://github.com/ceph/jerasure/blob/de1739cc8483696506829b52e7fda4f6bb195e6a/src/cauchy.c#L131-L147))
- デコードにかかる時間は O(k^2 * n) である。これは出力が全部で k * n エントリであり、出力の 1 エントリを埋めるために大きさ k のベクトル 2 個の内積を取る必要があるため。

reconstruct 時について、i 番目のデータフラグメントが欲しい場合は、上の B の逆行列の i 行目を取り出して掛ければ良い。行ベクトルと行列の掛け算なので、O(k * n) 時間でできる。
<img src="https://latex.codecogs.com/gif.latex?(B^{-1})_i&space;\begin{pmatrix}&space;f_0&space;\\&space;\vdots&space;\\&space;f_{k-1}&space;\end{pmatrix}&space;=&space;d_i">
i 番目のパリティフラグメントが欲しい場合は、以下の等式から、A_i B_f^{-1} を計算すれば良いのがわかる。(A_i は A の i 行目で、長さ k の行ベクトルである。)
<img src="https://latex.codecogs.com/gif.latex?A_i&space;B_f^{-1}&space;\begin{pmatrix}&space;f_0&space;\\&space;\vdots&space;\\&space;f_{k-1}&space;\end{pmatrix}&space;=&space;A_i&space;\begin{pmatrix}&space;d_0&space;\\&space;\vdots&space;\\&space;d_{k-1}&space;\end{pmatrix}&space;=&space;c_i">
A_i B^{-1} は長さ k の行ベクトルなので、フラグメントの復元は O(k * n) 時間でできる。

もともとの openstack/liberasurecode の実装では、データフラグメントの reconstruct 時には上に書かれたことをやっていたが、パリティフラグメントについてはやっておらず O(k^2 * n) 時間かかっていた。これをやるようにしたのが今回の変更である。

参考: http://jerasure.org/jerasure-2.0/

## 実装の注意点
GF(2^w)
- w bit の数。w 次元の 0/1 ベクトルとみなすこともでき、その場合足し算/引き算は要素ごとの xor である。GF(2^w) の2要素 a,b の掛け算を, a によって決まる w 次0/1正方行列 A とベクトル b の掛け算で実装することができる。
今回の実装は w が 32 以下ならどんな場合でも動くはず。rust-liberasurecode では w = 32 としており、単体テストもその設定で行われている。
https://github.com/frugalos/liberasurecode/blob/1.0.2/src/lib.rs#L155

行列
- 行列の要素は GF(2^w) の要素である。w <= 32 なので、各要素は int 一つに収まる。r * c 行列は sizeof(int) * r * c バイトの int 配列として表現されており、`int *matrix;` の i 行 j 列成分は `matrix[i * c + j]` に格納される。

bitmatrix
- GF(2^w) の要素のかけ算を避けるために bitmatrix と呼ばれる行列の表現方法が用意されており、rs_cauchy の様々な処理で bitmatrix が使われている。
bitmatrix は w = 1 とした普通の行列に他ならない。w = 1 なので要素は 0 か 1 である。
GF(2^w) 要素の r * c 行列を bitmatrix に変換すると (r * w) * (c * w) 行列になる。

## ベンチマーク
ecpool の https://github.com/frugalos/ecpool/blob/feature/bench-reconstruct/examples/reconstruct.rs を利用して、frugalos/liberasurecode のブランチを変更して k = 6, m = 3 の場合におけるパリティフラグメントの復元速度を比較した。
実行環境は手許の Linux マシンである。
比較対象は以下の通り:
- これを書いた当時の master ブランチhttps://github.com/frugalos/liberasurecode/commit/ddd49efdcc4c20d13cffbfdfaba13d6024c27dc9
- この変更を入れたブランチ https://github.com/frugalos/liberasurecode/pull/16/commits/377292afb8cd1a0e46214ca5accec10a56356afc

また reconstruct するフラグメントの設定は以下の通り:
- d1...d5, p0 が残っている状態で、p1 を復元
- d2...d5, p0, p1 が残っている状態で、p2 を復元

その他の設定は以下の通り:
- rustc 1.36.0 (a53f9df32 2019-07-03)
- release ビルド
- 1 GiB のファイルを作り、ecpool の encode でエンコードしたものに対して、reconstruct を実行する

### master ブランチ
```
$ target/release/examples/reconstruct -i 6p3/random.bin.data_1 6p3/random.bin.data_2 6p3/random.bin.data_3 6p3/random.bin.data_4 6p3/random.bin.data_5 6p3/random.bin.parity_0 -k 6 -m 3 -d 7
# INPUT FILE: 6p3/random.bin.data_1
# INPUT FILE: 6p3/random.bin.data_2
# INPUT FILE: 6p3/random.bin.data_3
# INPUT FILE: 6p3/random.bin.data_4
# INPUT FILE: 6p3/random.bin.data_5
# INPUT FILE: 6p3/random.bin.parity_0
# DECODE TIME: 2.085100512 sec
# DECODED SIZE: 178978896 
```
```
$ target/release/examples/reconstruct -i 6p3/random.bin.data_2 6p3/random.bin.data_3 6p3/random.bin.data_4 6p3/random.bin.data_5 6p3/random.bin.parity_0 6p3/random.bin.parity_1 -k 6 -m 3 -d 8
# INPUT FILE: 6p3/random.bin.data_2
# INPUT FILE: 6p3/random.bin.data_3
# INPUT FILE: 6p3/random.bin.data_4
# INPUT FILE: 6p3/random.bin.data_5
# INPUT FILE: 6p3/random.bin.parity_0
# INPUT FILE: 6p3/random.bin.parity_1
# DECODE TIME: 2.79097527 sec
# DECODED SIZE: 178978896 
```
### この変更を入れたブランチ
```
$ target/release/examples/reconstruct -i 6p3/random.bin.data_1 6p3/random.bin.data_2 6p3/random.bin.data_3 6p3/random.bin.data_4 6p3/random.bin.data_5 6p3/random.bin.parity_0 -k 6 -m 3 -d 7
# INPUT FILE: 6p3/random.bin.data_1
# INPUT FILE: 6p3/random.bin.data_2
# INPUT FILE: 6p3/random.bin.data_3
# INPUT FILE: 6p3/random.bin.data_4
# INPUT FILE: 6p3/random.bin.data_5
# INPUT FILE: 6p3/random.bin.parity_0
# DECODE TIME: 1.158771439 sec
# DECODED SIZE: 178978896 
```
```
$ target/release/examples/reconstruct -i 6p3/random.bin.data_2 6p3/random.bin.data_3 6p3/random.bin.data_4 6p3/random.bin.data_5 6p3/random.bin.parity_0 6p3/random.bin.parity_1 -k 6 -m 3 -d 8
# INPUT FILE: 6p3/random.bin.data_2
# INPUT FILE: 6p3/random.bin.data_3
# INPUT FILE: 6p3/random.bin.data_4
# INPUT FILE: 6p3/random.bin.data_5
# INPUT FILE: 6p3/random.bin.parity_0
# INPUT FILE: 6p3/random.bin.parity_1
# DECODE TIME: 1.001192458 sec
# DECODED SIZE: 178978896 
```

2~3 倍程度速くなっている。
