### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,7 +262,7 @@ impl ErasureCoder {
     /// Decodes the original data from the given fragments.
     pub fn decode<T: AsRef<[u8]>>(&mut self, fragments: &[T]) -> Result<Vec<u8>> {
         if fragments.is_empty() {
-            return Err(Error::InsufficientFragments);;
+            return Err(Error::InsufficientFragments);
         }
         let data_fragments = &fragments.iter().map(AsRef::as_ref).collect::<Vec<_>>()[..];
 
@@ -304,10 +304,10 @@ fn with_global_lock<F, T>(f: F) -> T
 where
     F: FnOnce() -> T,
 {
-    use std::sync::{Mutex, Once, ONCE_INIT};
+    use std::sync::{Mutex, Once};
 
     static mut MUTEX: Option<Mutex<()>> = None;
-    static INIT: Once = ONCE_INIT;
+    static INIT: Once = Once::new();
     INIT.call_once(|| unsafe {
         MUTEX = Some(Mutex::default());
     });

--- a/src/result.rs
+++ b/src/result.rs
@@ -92,7 +92,7 @@ impl error::Error for Error {
             Error::Other(_) => "Unknown error",
         }
     }
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         None
     }
 }


### PR DESCRIPTION
Rust コンパイラのアップデートで CI が落ちていたため。