### PR TITLE
Use libgf_complete.a in compiling liberasurecode

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -47,6 +47,6 @@ if [ "$(uname)" == "Darwin" ]; then
     patch -p1 < ../for_darwin_to_detect_compiler_flag.patch
 fi
 ./autogen.sh
-LIBS="-lJerasure" ./configure --disable-shared --with-pic --prefix $BUILD_DIR
+LIBS="-lJerasure -lgf_complete" ./configure --disable-shared --with-pic --prefix $BUILD_DIR
 patch -p1 < ../liberasurecode.patch # Applies a patch for building static library
 make $MAKE_FLAGS install


### PR DESCRIPTION
おそらく MacOS 限定だが、以下のような gf_complete 関連のシンボルが見つからないというエラーが出ていたため、そのための修正を施した。(gcc でも clang でもエラーが出る)
なぜ Linux 環境でこのエラーが出ないのかは不明。

バージョン情報:
```
$ sw_vers 
ProductName:	Mac OS X
ProductVersion:	10.13.6
BuildVersion:	17G9016

$ gcc --version
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 10.0.0 (clang-1000.11.45.5)
Target: x86_64-apple-darwin17.7.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin

$ clang --version
Apple LLVM version 10.0.0 (clang-1000.11.45.5)
Target: x86_64-apple-darwin17.7.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

エラー:
```
$ CC=gcc cargo c
   Compiling liberasurecode v1.0.3
error: failed to run custom build command for `liberasurecode v1.0.3`

Caused by:
  process didn't exit successfully: `/Users/koba_mac/srcview/frugalos/target/debug/build/liberasurecode-080c903d0e0b4cfa/build-script-build` (exit code: 101)
--- stdout
cargo:rerun-if-changed=build.rs

--- stderr
+ BUILD_DIR=/Users/koba_mac/srcview/frugalos/target/debug/build/liberasurecode-7d7bfd32bb7fc684/out/build
+ MAKE_FLAGS=
+ export CPATH=/Users/koba_mac/srcview/frugalos/target/debug/build/liberasurecode-7d7bfd32bb7fc684/out/build/include:/Users/koba_mac/srcview/frugalos/target/debug/build/liberasurecode-7d7bfd32bb7fc684/out/build/include/jerasure:
+ CPATH=/Users/koba_mac/srcview/frugalos/target/debug/build/liberasurecode-7d7bfd32bb7fc684/out/build/include:/Users/koba_mac/srcview/frugalos/target/debug/build/liberasurecode-7d7bfd32bb7fc684/out/build/include/jerasure:
+ export LIBRARY_PATH=/Users/koba_mac/srcview/frugalos/target/debug/build/liberasurecode-7d7bfd32bb7fc684/out/build/lib:
+ LIBRARY_PATH=/Users/koba_mac/srcview/frugalos/target/debug/build/liberasurecode-7d7bfd32bb7fc684/out/build/lib:
+ case "$(uname)" in
++ uname
++ sysctl -n hw.ncpu
+ MAKE_FLAGS=-j4
+ git clone https://github.com/ceph/gf-complete.git
Cloning into 'gf-complete'...
+ cd gf-complete/
+ git checkout a6862d1
Note: switching to 'a6862d1'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at a6862d1 Merge branch 'wip-signed-integer-overflow-cppcheck' into 'master'
+ ./autogen.sh
configure.ac:12: installing './compile'
configure.ac:12: installing './config.guess'
configure.ac:12: installing './config.sub'
configure.ac:11: installing './install-sh'
configure.ac:11: installing './missing'
parallel-tests: installing './test-driver'
+ ./configure --disable-shared --with-pic --prefix /Users/koba_mac/srcview/frugalos/target/debug/build/liberasurecode-7d7bfd32bb7fc684/out/build
rm: conftest.dSYM: is a directory
rm: conftest.dSYM: is a directory
rm: conftest.dSYM: is a directory
rm: conftest.dSYM: is a directory
+ make -j4 install
gf_w32.c:854:1: warning: unused function 'gf_w32_group_4_4_multiply' [-Wunused-function]
gf_w32_group_4_4_multiply(gf_t *gf, gf_val_32_t a, gf_val_32_t b)
^
1 warning generated.
+ cd ../
+ git clone https://github.com/ceph/jerasure.git
Cloning into 'jerasure'...
+ cd jerasure/
+ git checkout de1739c
Note: switching to 'de1739c'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at de1739c Merge branch 'wip-signed-integer-overflow-cppcheck' into 'master'
+ autoreconf --force --install
configure.ac:18: installing 'build-aux/compile'
configure.ac:18: installing 'build-aux/config.guess'
configure.ac:18: installing 'build-aux/config.sub'
configure.ac:12: installing 'build-aux/install-sh'
configure.ac:12: installing 'build-aux/missing'
Examples/Makefile.am: installing 'build-aux/depcomp'
parallel-tests: installing 'build-aux/test-driver'
Makefile.am: installing './INSTALL'
+ ./configure --disable-shared --enable-static --with-pic --prefix /Users/koba_mac/srcview/frugalos/target/debug/build/liberasurecode-7d7bfd32bb7fc684/out/build
rm: conftest.dSYM: is a directory
rm: conftest.dSYM: is a directory
rm: conftest.dSYM: is a directory
rm: conftest.dSYM: is a directory
+ make -j4 install
+ cd ../
+ git clone https://github.com/openstack/liberasurecode.git
Cloning into 'liberasurecode'...
+ cd liberasurecode/
+ git checkout 1.5.0
Note: switching to '1.5.0'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 24038b3 Merge "Release 1.5.0"
++ uname
+ '[' Darwin == Darwin ']'
+ patch -p1
+ ./autogen.sh
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force 
autoreconf: configure.ac: tracing
autoreconf: running: glibtoolize --copy --force
autoreconf: running: /usr/local/Cellar/autoconf/2.69/bin/autoconf --force
autoreconf: running: /usr/local/Cellar/autoconf/2.69/bin/autoheader --force
autoreconf: running: automake --add-missing --copy --force-missing
configure.ac:32: installing './compile'
configure.ac:35: installing './config.guess'
configure.ac:35: installing './config.sub'
configure.ac:34: installing './install-sh'
configure.ac:34: installing './missing'
Makefile.am: installing './INSTALL'
src/Makefile.am: installing './depcomp'
autoreconf: Leaving directory `.'
+ LIBS=-lJerasure
+ ./configure --disable-shared --with-pic --prefix /Users/koba_mac/srcview/frugalos/target/debug/build/liberasurecode-7d7bfd32bb7fc684/out/build
+ patch -p1
+ make -j4 install
erasurecode_helpers.c:530:26: warning: taking address of packed member 'metadata_chksum' of class or structure 'fragment_header_s' may result in an unaligned pointer value [-Waddress-of-packed-member]
    return (uint32_t *) &header->metadata_chksum;
                         ^~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
Undefined symbols for architecture x86_64:
  "_gf_free", referenced from:
      _galois_uninit_field in libJerasure.a(galois.o)
      _galois_change_technique in libJerasure.a(galois.o)
  "_gf_init_easy", referenced from:
      _galois_init_default_field in libJerasure.a(galois.o)
      _galois_init in libJerasure.a(galois.o)
  "_gf_init_hard", referenced from:
      _galois_init_field in libJerasure.a(galois.o)
      _galois_init_composite_field in libJerasure.a(galois.o)
  "_gf_scratch_size", referenced from:
      _galois_init_field in libJerasure.a(galois.o)
      _galois_init_composite_field in libJerasure.a(galois.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [alg_sig_test] Error 1
make[1]: *** Waiting for unfinished jobs....
Undefined symbols for architecture x86_64:
  "_gf_free", referenced from:
      _galois_uninit_field in libJerasure.a(galois.o)
      _galois_change_technique in libJerasure.a(galois.o)
  "_gf_init_easy", referenced from:
      _galois_init_default_field in libJerasure.a(galois.o)
      _galois_init in libJerasure.a(galois.o)
  "_gf_init_hard", referenced from:
      _galois_init_field in libJerasure.a(galois.o)
      _galois_init_composite_field in libJerasure.a(galois.o)
      _reed_sol_galois_w08_region_multby_2 in libJerasure.a(reed_sol.o)
      _reed_sol_galois_w16_region_multby_2 in libJerasure.a(reed_sol.o)
      _reed_sol_galois_w32_region_multby_2 in libJerasure.a(reed_sol.o)
  "_gf_scratch_size", referenced from:
      _galois_init_field in libJerasure.a(galois.o)
      _galois_init_composite_field in libJerasure.a(galois.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [libec_slap] Error 1
make: *** [install-recursive] Error 1
thread 'main' panicked at './install_deps.sh failed: exit-code=Some(2)', /Users/koba_mac/.cargo/registry/src/github.com-1ecc6299db9ec823/liberasurecode-1.0.3/build.rs:32:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.

```